### PR TITLE
fix: closing a bubble breaks showing next

### DIFF
--- a/src/systems.ts
+++ b/src/systems.ts
@@ -47,7 +47,7 @@ export function handleDialogTyping(dt:number) {
     for (const [entity] of engine.getEntitiesWith(IsTypingBubble)) {
         let dialogData = bubbles.get(entity)
         if(dialogData.done){
-            return
+            continue
         }
 
         dialogData.timer += dt


### PR DESCRIPTION
can't start a conversation between NPCs
systems.handleBubbleTyping used to return from the method when It cycles through an entity with the isTypingBubble component .done without removing the component so once a bubble dialog is closed, the system can't reach any more bubbles in the array